### PR TITLE
Add `InjectManifest` plugin to webpack dev config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Uncomment the line below inside /src/index.html to enable it.
 </script>
 ```
 
+If you want to use ServiceWorker in development mode, you also have to uncomment **all commented lines** in `/webpack/webpack.dev.js`
+
+
 You can easily personalize its settings by following these steps:
 
 - Replace both icons in /pwa/icons with your own.

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,5 +1,8 @@
 const { merge } = require('webpack-merge')
 const common = require('./webpack.common')
+// Uncomment this to use SW in development
+// const path = require('path')
+// const { InjectManifest } = require('workbox-webpack-plugin')
 
 const dev = {
   mode: 'development',
@@ -7,7 +10,15 @@ const dev = {
   devtool: 'eval',
   devServer: {
     open: true
-  }
+  },
+  // Uncomment this to use SW in development
+  // plugins: [
+  //   new InjectManifest({
+  //     swSrc: path.resolve(__dirname, '../pwa/sw.js'),
+  //     swDest: 'sw.js',
+  //     maximumFileSizeToCacheInBytes: 10000000
+  //   })
+  // ]
 }
 
 module.exports = merge(common, dev)


### PR DESCRIPTION
Hey!

First of all, thanks for beautiful template. I tried Phaser3 and was frustrated with example project, since it used Parcel and nothing seemed to work. Your template works like a charm.
However i encountered problem when i uncommented lines in `index.html`. The error was `Cannot use import statement outside module`
Upon further investigation i found out, that this was because webpack plugin for Workbox was used only in production config. I added the plugin and also added parameter `maximumFileSizeToCacheInBytes` since webpack complained about filesize (disabled minification on dev).

In this PR i add the plugin into dev config and update the `README.md`. With these changes SW can be run and tried in dev too